### PR TITLE
Added setters to LdapConfig to better support Spring @ConfigProps

### DIFF
--- a/cert-ldap-login-module-common/src/main/java/org/esbtools/auth/ldap/LdapConfiguration.java
+++ b/cert-ldap-login-module-common/src/main/java/org/esbtools/auth/ldap/LdapConfiguration.java
@@ -179,4 +179,60 @@ public class LdapConfiguration {
             ", retryIntervalSeconds=" + retryIntervalSeconds +
             '}';
     }
+
+    public void setServer(String server) {
+      this.server = server;
+    }
+
+    public void setPort(Integer port) {
+      this.port = port;
+    }
+
+    public void setBindDn(String bindDn) {
+      this.bindDn = bindDn;
+    }
+
+    public void setBindDNPwd(String bindDNPwd) {
+      this.bindDNPwd = bindDNPwd;
+    }
+
+    public void setUseSSL(Boolean useSSL) {
+      this.useSSL = useSSL;
+    }
+
+    public void setTrustStore(String trustStore) {
+      this.trustStore = trustStore;
+    }
+
+    public void setTrustStorePassword(String trustStorePassword) {
+      this.trustStorePassword = trustStorePassword;
+    }
+
+    public void setPoolSize(Integer poolSize) {
+      this.poolSize = poolSize;
+    }
+
+    public void setPoolMaxConnectionAgeMS(Integer poolMaxConnectionAgeMS) {
+      this.poolMaxConnectionAgeMS = poolMaxConnectionAgeMS;
+    }
+
+    public void setConnectionTimeoutMS(Integer connectionTimeoutMS) {
+      this.connectionTimeoutMS = connectionTimeoutMS;
+    }
+
+    public void setResponseTimeoutMS(Integer responseTimeoutMS) {
+      this.responseTimeoutMS = responseTimeoutMS;
+    }
+
+    public void setDebug(boolean debug) {
+      this.debug = debug;
+    }
+
+    public void setKeepAlive(boolean keepAlive) {
+      this.keepAlive = keepAlive;
+    }
+
+    public void setRetryIntervalSeconds(Integer retryIntervalSeconds) {
+      this.retryIntervalSeconds = retryIntervalSeconds;
+    }
 }


### PR DESCRIPTION
Spring external configuration injection relies on ctors or setters. Essentially lets us do:
```
  @Bean
  @ConfigurationProperties(prefix = "ldap")
  public LdapConfiguration ldapConfiguration() {
    return new LdapConfiguration();
  }
```
Instead of:
```
 @Bean
  public LdapConfiguration ldapConfiguration(
      @Value("${ldapconfig.server}") String server,
      @Value("${ldapconfig.port}") Integer port,
      @Value("${ldapconfig.username}") String bindDn,
      @Value("${ldapconfig.password}") String bindDNPwd,
      @Value("${ldapconfig.pool_size}") Integer poolSize,
      @Value("${ldapconfig.use_tls}") Boolean useSSL,
      @Value("${ldapconfig.truststore}") String trustStore,
      @Value("${ldapconfig.truststore_password}") String trustStorePassword,
      @Value("${ldapconfig.connectionTimeoutMS}") Integer connectionTimeoutMS,
      @Value("${ldapconfig.responseTimeoutMS}") Integer responseTimeoutMS,
      @Value("${ldapconfig.debug}") Boolean debug,
      @Value("${ldapconfig.keepAlive}") Boolean keepAlive,
      @Value("${ldapconfig.poolMaxConnectionAgeMS}") Integer poolMaxConnectionAgeMS) {

    LdapConfiguration config = new LdapConfiguration();
    config.server(server);
    config.port(port);
    config.bindDn(bindDn);
    config.bindDNPwd(bindDNPwd);
    config.poolSize(poolSize);
    config.useSSL(useSSL);
    config.trustStore(trustStore);
    config.trustStorePassword(trustStorePassword);
    config.connectionTimeoutMS(connectionTimeoutMS);
    config.responseTimeoutMS(responseTimeoutMS);
    config.debug(debug);
    config.keepAlive(keepAlive);
    config.poolMaxConnectionAgeMS(poolMaxConnectionAgeMS);

    return config;
```